### PR TITLE
Upgrade to bs-platform v7

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "npmpub": "^5.0.0",
     "prettier": "^1.16.4",
     "reason-react": "^0.7.0",
-    "reason-react-native": "^0.60.1"
+    "reason-react-native": "^0.61.1"
   },
   "prettier": {
     "trailingComma": "all",

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "release": "npmpub"
   },
   "devDependencies": {
-    "bs-platform": "^5.0.4",
+    "bs-platform": "^7.2.2",
     "husky": "^1.3.1",
     "lerna": "^3.4.0",
     "lint-staged": "^8.1.5",

--- a/src/RNEvent.re
+++ b/src/RNEvent.re
@@ -2,16 +2,17 @@ type t;
 
 module NativeEvent = {
   type t = ReactNative.Event.pressEvent;
-  [@bs.get] external changedTouches: t => array(Js.t({..})) = "";
-  [@bs.get] external identifier: t => int = "";
-  [@bs.get] external locationX: t => float = "";
-  [@bs.get] external locationY: t => float = "";
-  [@bs.get] external pageX: t => float = "";
-  [@bs.get] external pageY: t => float = "";
-  [@bs.get] external target: t => Js.t({..}) = "";
-  [@bs.get] external touches: t => array(Js.t({..})) = "";
-  [@bs.get] external timestamp: t => int = "";
-  [@bs.get] external data: t => string = "";
+  [@bs.get]
+  external changedTouches: t => array(Js.t({..})) = "changedTouches";
+  [@bs.get] external identifier: t => int = "identifier";
+  [@bs.get] external locationX: t => float = "locationX";
+  [@bs.get] external locationY: t => float = "locationY";
+  [@bs.get] external pageX: t => float = "pageX";
+  [@bs.get] external pageY: t => float = "pageY";
+  [@bs.get] external target: t => Js.t({..}) = "target";
+  [@bs.get] external touches: t => array(Js.t({..})) = "touches";
+  [@bs.get] external timestamp: t => int = "timestamp";
+  [@bs.get] external data: t => string = "data";
 };
 
 /*
@@ -70,7 +71,7 @@ module NativeScrollEvent = {
   };
 };
 
-[@bs.get] external nativeEvent: t => NativeEvent.t = "";
+[@bs.get] external nativeEvent: t => NativeEvent.t = "nativeEvent";
 
 [@bs.get] external nativeLayoutEvent: t => NativeLayoutEvent.t = "nativeEvent";
 

--- a/src/animatedRe.re
+++ b/src/animatedRe.re
@@ -6,8 +6,8 @@ module Animation = {
   external _start: (t, Js.undefined(endCallback)) => unit = "start";
   let start = (t, ~callback=?, ()) =>
     _start(t, Js.Undefined.fromOption(callback));
-  [@bs.send] external stop: t => unit = "";
-  [@bs.send] external reset: t => unit = "";
+  [@bs.send] external stop: t => unit = "stop";
+  [@bs.send] external reset: t => unit = "reset";
 };
 
 module type Value = {
@@ -36,8 +36,7 @@ module ValueAnimations = (Val: Value) => {
         ~onComplete: Animation.endCallback=?,
         ~iterations: int=?
       ) =>
-      config =
-      "";
+      config;
     [@bs.module "react-native"] [@bs.scope "Animated"]
     external _decay: (Val.t, config) => Animation.t = "decay";
     let animate =
@@ -86,8 +85,7 @@ module ValueAnimations = (Val: Value) => {
         ~onComplete: Animation.endCallback=?,
         ~iterations: int=?
       ) =>
-      config =
-      "";
+      config;
     external toValueRaw: Val.rawJsType => toValue = "%identity";
     external toValueAnimated: Val.t => toValue = "%identity";
     [@bs.module "react-native"] [@bs.scope "Animated"]
@@ -154,8 +152,7 @@ module ValueAnimations = (Val: Value) => {
         ~onComplete: Animation.endCallback=?,
         ~iterations: int=?
       ) =>
-      config =
-      "";
+      config;
     external toValueRaw: Val.rawJsType => toValue = "%identity";
     external toValueAnimated: Val.t => toValue = "%identity";
     [@bs.module "react-native"] [@bs.scope "Animated"]
@@ -218,8 +215,7 @@ module Interpolation = {
       ~extrapolateLeft: string=?,
       ~extrapolateRight: string=?
     ) =>
-    config =
-    "";
+    config;
   [@bs.send] external _interpolate: (value('a), config) => t = "interpolate";
   let interpolate =
       (
@@ -253,17 +249,20 @@ module Interpolation = {
 
 module ValueOperations = {
   [@bs.module "react-native"] [@bs.scope "Animated"]
-  external add: (value('a), value('b)) => value(calculated) = "";
+  external add: (value('a), value('b)) => value(calculated) = "add";
   [@bs.module "react-native"] [@bs.scope "Animated"]
-  external divide: (value('a), value('b)) => value(calculated) = "";
+  external divide: (value('a), value('b)) => value(calculated) = "divide";
   [@bs.module "react-native"] [@bs.scope "Animated"]
-  external multiply: (value('a), value('b)) => value(calculated) = "";
+  external multiply: (value('a), value('b)) => value(calculated) =
+    "multiply";
   [@bs.module "react-native"] [@bs.scope "Animated"]
-  external modulo: (value('a), float) => value(calculated) = "";
+  external modulo: (value('a), float) => value(calculated) = "modulo";
   [@bs.module "react-native"] [@bs.scope "Animated"]
-  external subtract: (value('a), value('b)) => value(calculated) = "";
+  external subtract: (value('a), value('b)) => value(calculated) =
+    "subtract";
   [@bs.module "react-native"] [@bs.scope "Animated"]
-  external diffClamp: (value('a), float, float) => value(calculated) = "";
+  external diffClamp: (value('a), float, float) => value(calculated) =
+    "diffClamp";
   let interpolate = Interpolation.interpolate;
 };
 
@@ -344,18 +343,18 @@ module ValueXY = {
 };
 
 [@bs.module "react-native"] [@bs.scope "Animated"]
-external delay: float => Animation.t = "";
+external delay: float => Animation.t = "delay";
 
 [@bs.module "react-native"] [@bs.scope "Animated"]
-external sequence: array(Animation.t) => Animation.t = "";
+external sequence: array(Animation.t) => Animation.t = "sequence";
 
 [@bs.module "react-native"] [@bs.scope "Animated"]
 external parallel:
   (array(Animation.t), {. "stopTogether": bool}) => Animation.t =
-  "";
+  "parallel";
 
 [@bs.module "react-native"] [@bs.scope "Animated"]
-external stagger: (float, array(Animation.t)) => Animation.t = "";
+external stagger: (float, array(Animation.t)) => Animation.t = "stagger";
 
 [@bs.module "react-native"] [@bs.scope "Animated"]
 external _loop: (Animation.t, {. "iterations": int}) => Animation.t = "loop";
@@ -366,12 +365,12 @@ let loop = (~iterations=(-1), ~animation, ()) =>
 type animatedEvent;
 
 [@bs.module "react-native"] [@bs.scope "Animated"]
-external event: (array('a), 'b) => animatedEvent = "";
+external event: (array('a), 'b) => animatedEvent = "event";
 
 [@bs.module "react-native"] [@bs.scope "Animated"]
 external createAnimatedComponent:
   ReasonReact.reactClass => ReasonReact.reactClass =
-  "";
+  "createAnimatedComponent";
 
 let timing = Value.Timing.animate;
 

--- a/src/appState.re
+++ b/src/appState.re
@@ -16,7 +16,8 @@ let currentState = () => {
 };
 
 [@bs.scope "AppState"] [@bs.module "react-native"]
-external addEventListener: (string, unit => unit) => unit = "";
+external addEventListener: (string, unit => unit) => unit = "addEventListener";
 
 [@bs.scope "AppState"] [@bs.module "react-native"]
-external removeEventListener: (string, unit => unit) => unit = "";
+external removeEventListener: (string, unit => unit) => unit =
+  "removeEventListener";

--- a/src/appState.rei
+++ b/src/appState.rei
@@ -16,7 +16,8 @@ type state =
 let currentState: unit => state;
 
 [@bs.scope "AppState"] [@bs.module "react-native"]
-external addEventListener: (string, unit => unit) => unit = "";
+external addEventListener: (string, unit => unit) => unit = "addEventListener";
 
 [@bs.scope "AppState"] [@bs.module "react-native"]
-external removeEventListener: (string, unit => unit) => unit = "";
+external removeEventListener: (string, unit => unit) => unit =
+  "removeEventListener";

--- a/src/asyncStorage.re
+++ b/src/asyncStorage.re
@@ -93,7 +93,7 @@ let getAllKeys = (~callback=?, ()) =>
   };
 
 [@bs.scope "AsyncStorage"] [@bs.module "react-native"]
-external flushGetRequests: unit => unit = "";
+external flushGetRequests: unit => unit = "flushGetRequests";
 
 [@bs.scope "AsyncStorage"] [@bs.module "react-native"]
 external _multiGet:

--- a/src/asyncStorage.rei
+++ b/src/asyncStorage.rei
@@ -124,7 +124,7 @@ let getAllKeys:
   Js.Promise.t(option(array(string)));
 
 [@bs.scope "AsyncStorage"] [@bs.module "react-native"]
-external flushGetRequests: unit => unit = "";
+external flushGetRequests: unit => unit = "flushGetRequests";
 
 let multiGet:
   (

--- a/src/backHandler.re
+++ b/src/backHandler.re
@@ -1,8 +1,9 @@
 [@bs.scope "BackHandler"] [@bs.module "react-native"]
-external exitApp: unit => unit = "";
+external exitApp: unit => unit = "exitApp";
 
 [@bs.scope "BackHandler"] [@bs.module "react-native"]
-external addEventListener: (string, unit => bool) => unit = "";
+external addEventListener: (string, unit => bool) => unit = "addEventListener";
 
 [@bs.scope "BackHandler"] [@bs.module "react-native"]
-external removeEventListener: (string, unit => bool) => unit = "";
+external removeEventListener: (string, unit => bool) => unit =
+  "removeEventListener";

--- a/src/backHandler.rei
+++ b/src/backHandler.rei
@@ -27,10 +27,11 @@ You can read more on [BackHandler] API usage in official docs: {{:https://facebo
 ]}
 */
 [@bs.scope "BackHandler"] [@bs.module "react-native"]
-external exitApp: unit => unit = "";
+external exitApp: unit => unit = "exitApp";
 
 [@bs.scope "BackHandler"] [@bs.module "react-native"]
-external addEventListener: (string, unit => bool) => unit = "";
+external addEventListener: (string, unit => bool) => unit = "addEventListener";
 
 [@bs.scope "BackHandler"] [@bs.module "react-native"]
-external removeEventListener: (string, unit => bool) => unit = "";
+external removeEventListener: (string, unit => bool) => unit =
+  "removeEventListener";

--- a/src/clipboard.re
+++ b/src/clipboard.re
@@ -1,5 +1,5 @@
 [@bs.module "react-native"] [@bs.scope "Clipboard"]
-external getString: unit => Js.Promise.t(string) = "";
+external getString: unit => Js.Promise.t(string) = "getString";
 
 [@bs.module "react-native"] [@bs.scope "Clipboard"]
-external setString: string => unit = "";
+external setString: string => unit = "setString";

--- a/src/components/flatList.re
+++ b/src/components/flatList.re
@@ -78,7 +78,8 @@ let scrollToOffset = (ref, ~offset=?, ~animated=?, ()) =>
     },
   );
 
-[@bs.send] external recordInteraction: ReasonReact.reactRef => unit = "";
+[@bs.send]
+external recordInteraction: ReasonReact.reactRef => unit = "recordInteraction";
 
 type jsRenderBag('item) = {
   .

--- a/src/components/flatList.rei
+++ b/src/components/flatList.rei
@@ -294,7 +294,7 @@ let scrollToOffset:
   {2 API reference}
   */
 [@bs.send]
-external recordInteraction: ReasonReact.reactRef => unit = "";
+external recordInteraction: ReasonReact.reactRef => unit = "recordInteraction";
 
 type renderBag('item) = {
   item: 'item,

--- a/src/components/image.re
+++ b/src/components/image.re
@@ -25,8 +25,7 @@ external _imageURISource:
     ~height: option(float)=?,
     unit
   ) =>
-  _imageURISource =
-  "";
+  _imageURISource;
 
 type imageURISource = ReactNative.Image.Source.t;
 let imageURISource =
@@ -71,8 +70,7 @@ external _defaultURISource:
     ~height: option(float)=?,
     unit
   ) =>
-  _defaultURISource =
-  "";
+  _defaultURISource;
 
 type defaultURISource;
 let defaultURISource = (~uri, ~scale=?, ~width=?, ~height=?, unit) =>
@@ -166,4 +164,4 @@ type asset = {
 type assetSource = [ | `URI(_imageURISource) | `Required(Packager.required)];
 
 [@bs.scope "Image"] [@bs.module "react-native"]
-external resolveAssetSource: assetSource => asset = "";
+external resolveAssetSource: assetSource => asset = "resolveAssetSource";

--- a/src/components/textInput.re
+++ b/src/components/textInput.re
@@ -140,7 +140,7 @@ let make =
     ) =>
   <ReactNative.TextInput
     ?autoCapitalize
-    ?autoComplete
+    autoCompleteType=?autoComplete
     ?autoCorrect
     ?autoFocus
     ?blurOnSubmit

--- a/src/components/textInput.re
+++ b/src/components/textInput.re
@@ -1,10 +1,10 @@
-[@bs.send] external isFocused: ReasonReact.reactRef => bool = "";
+[@bs.send] external isFocused: ReasonReact.reactRef => bool = "isFocused";
 
-[@bs.send] external clear: ReasonReact.reactRef => unit = "";
+[@bs.send] external clear: ReasonReact.reactRef => unit = "clear";
 
-[@bs.send] external focus: ReasonReact.reactRef => unit = "";
+[@bs.send] external focus: ReasonReact.reactRef => unit = "focus";
 
-[@bs.send] external blur: ReasonReact.reactRef => unit = "";
+[@bs.send] external blur: ReasonReact.reactRef => unit = "blur";
 
 type editingEvent = ReactNative.TextInput.editingEvent;
 

--- a/src/components/viewPagerAndroid.re
+++ b/src/components/viewPagerAndroid.re
@@ -1,4 +1,4 @@
-[@bs.send] external setPage: (ReasonReact.reactRef, int) => unit = "";
+[@bs.send] external setPage: (ReasonReact.reactRef, int) => unit = "setPage";
 
 [@react.component]
 let make =

--- a/src/components/webView.re
+++ b/src/components/webView.re
@@ -15,22 +15,20 @@ external sourceUri:
     ~body: string=?,
     unit
   ) =>
-  source =
-  "";
+  source;
 
 [@bs.obj]
-external sourceHtml: (~html: string=?, ~baseUrl: string=?, unit) => source =
-  "";
+external sourceHtml: (~html: string=?, ~baseUrl: string=?, unit) => source;
 
 let source = sourceUri;
 
-[@bs.send] external goForward: ReasonReact.reactRef => unit = "";
+[@bs.send] external goForward: ReasonReact.reactRef => unit = "goForward";
 
-[@bs.send] external goBack: ReasonReact.reactRef => unit = "";
+[@bs.send] external goBack: ReasonReact.reactRef => unit = "goBack";
 
-[@bs.send] external reload: ReasonReact.reactRef => unit = "";
+[@bs.send] external reload: ReasonReact.reactRef => unit = "reload";
 
-[@bs.send] external stopLoading: ReasonReact.reactRef => unit = "";
+[@bs.send] external stopLoading: ReasonReact.reactRef => unit = "stopLoading";
 
 [@react.component]
 let make =

--- a/src/dimensions.re
+++ b/src/dimensions.re
@@ -30,7 +30,7 @@ external addEventListener:
     unit
   ) =>
   unit =
-  "";
+  "addEventListener";
 
 [@bs.scope "Dimensions"] [@bs.module "react-native"]
 external removeEventListener:
@@ -44,4 +44,4 @@ external removeEventListener:
     unit
   ) =>
   unit =
-  "";
+  "removeEventListener";

--- a/src/dimensions.rei
+++ b/src/dimensions.rei
@@ -117,7 +117,7 @@ external addEventListener:
     unit
   ) =>
   unit =
-  "";
+  "addEventListener";
 
 [@bs.scope "Dimensions"] [@bs.module "react-native"]
 external removeEventListener:
@@ -131,4 +131,4 @@ external removeEventListener:
     unit
   ) =>
   unit =
-  "";
+  "removeEventListener";

--- a/src/easing.re
+++ b/src/easing.re
@@ -1,24 +1,25 @@
 type t = float => float;
-[@bs.module "react-native"] [@bs.scope "Easing"] external bounce: t = "";
-[@bs.module "react-native"] [@bs.scope "Easing"] external circle: t = "";
-[@bs.module "react-native"] [@bs.scope "Easing"] external cubic: t = "";
-[@bs.module "react-native"] [@bs.scope "Easing"] external ease: t = "";
-[@bs.module "react-native"] [@bs.scope "Easing"] external exp: t = "";
-[@bs.module "react-native"] [@bs.scope "Easing"] external linear: t = "";
+[@bs.module "react-native"] [@bs.scope "Easing"] external bounce: t = "bounce";
+[@bs.module "react-native"] [@bs.scope "Easing"] external circle: t = "circle";
+[@bs.module "react-native"] [@bs.scope "Easing"] external cubic: t = "cubic";
+[@bs.module "react-native"] [@bs.scope "Easing"] external ease: t = "ease";
+[@bs.module "react-native"] [@bs.scope "Easing"] external exp: t = "exp";
+[@bs.module "react-native"] [@bs.scope "Easing"] external linear: t = "linear";
 [@bs.module "react-native"] [@bs.scope "Easing"]
-external poly: float => t = "";
-[@bs.module "react-native"] [@bs.scope "Easing"] external quad: t = "";
-[@bs.module "react-native"] [@bs.scope "Easing"] external sin: t = "";
+external poly: float => t = "poly";
+[@bs.module "react-native"] [@bs.scope "Easing"] external quad: t = "quad";
+[@bs.module "react-native"] [@bs.scope "Easing"] external sin: t = "sin";
 [@bs.module "react-native"] [@bs.scope "Easing"]
-external step0: float => int = "";
+external step0: float => int = "step";
 [@bs.module "react-native"] [@bs.scope "Easing"]
-external step1: float => int = "";
+external step1: float => int = "step";
 [@bs.module "react-native"] [@bs.scope "Easing"]
-external back: float => t = "";
+external back: float => t = "back";
 [@bs.module "react-native"] [@bs.scope "Easing"]
-external elastic: float => t = "";
+external elastic: float => t = "elastic";
 [@bs.module "react-native"] [@bs.scope "Easing"] external in_: t => t = "in";
-[@bs.module "react-native"] [@bs.scope "Easing"] external inOut: t => t = "";
-[@bs.module "react-native"] [@bs.scope "Easing"] external out: t => t = "";
 [@bs.module "react-native"] [@bs.scope "Easing"]
-external bezier: (float, float, float, float) => t = "";
+external inOut: t => t = "inOut";
+[@bs.module "react-native"] [@bs.scope "Easing"] external out: t => t = "out";
+[@bs.module "react-native"] [@bs.scope "Easing"]
+external bezier: (float, float, float, float) => t = "bezier";

--- a/src/geolocation.re
+++ b/src/geolocation.re
@@ -28,14 +28,12 @@ type error = {
 
 [@bs.obj]
 external makeGeolocationConfig:
-  (~skipPermissionRequests: bool=?) => geolactionConfig =
-  "";
+  (~skipPermissionRequests: bool=?) => geolactionConfig;
 
 [@bs.obj]
 external makeCurrentPositionConfig:
   (~timeout: int=?, ~maximumAge: int=?, ~enableHighAccuracy: bool=?) =>
-  currentPositionConfig =
-  "";
+  currentPositionConfig;
 
 [@bs.obj]
 external makeWatchPositionConfig:
@@ -46,25 +44,24 @@ external makeWatchPositionConfig:
     ~distanceFilter: int=?,
     ~useSignificantChanges: bool=?
   ) =>
-  watchPositionConfig =
-  "";
+  watchPositionConfig;
 
 [@bs.val] [@bs.scope ("navigator", "geolocation")]
-external setRNConfiguration: geolactionConfig => unit = "";
+external setRNConfiguration: geolactionConfig => unit = "setRNConfiguration";
 
 let setRNConfiguration = (~skipPermissionRequests=?, ()) =>
   setRNConfiguration(makeGeolocationConfig(~skipPermissionRequests?));
 
 [@bs.val] [@bs.scope ("navigator", "geolocation")]
-external requestAuthorization: unit => unit = "";
+external requestAuthorization: unit => unit = "requestAuthorization";
 
 [@bs.val] [@bs.scope ("navigator", "geolocation")]
-external stopObserving: unit => unit = "";
+external stopObserving: unit => unit = "stopObserving";
 
 [@bs.val] [@bs.scope ("navigator", "geolocation")]
 external getCurrentPosition:
   (position => unit, error => unit, currentPositionConfig) => unit =
-  "";
+  "getCurrentPosition";
 
 let getCurrentPosition =
     (~timeout=?, ~maximumAge=?, ~enableHighAccuracy=?, success, error) =>
@@ -77,7 +74,7 @@ let getCurrentPosition =
 [@bs.val] [@bs.scope ("navigator", "geolocation")]
 external watchPosition:
   (position => unit, error => unit, watchPositionConfig) => watchId =
-  "";
+  "watchPosition";
 
 let watchPosition =
     (
@@ -102,4 +99,4 @@ let watchPosition =
   );
 
 [@bs.val] [@bs.scope ("navigator", "geolocation")]
-external clearWatch: watchId => unit = "";
+external clearWatch: watchId => unit = "clearWatch";

--- a/src/imagePickerIOS.re
+++ b/src/imagePickerIOS.re
@@ -1,8 +1,8 @@
 [@bs.module "react-native"] [@bs.scope "ImagePickerIOS"]
-external canUseCamera: (unit => unit) => unit = "";
+external canUseCamera: (unit => unit) => unit = "canUseCamera";
 
 [@bs.module "react-native"] [@bs.scope "ImagePickerIOS"]
-external canRecordVideos: (unit => unit) => unit = "";
+external canRecordVideos: (unit => unit) => unit = "canRecordVideos";
 
 type error = {
   .
@@ -13,12 +13,12 @@ type error = {
 type cameraDialogConfig = {. "videoMode": bool};
 
 [@bs.obj]
-external makeCameraDialogConfig: (~videoMode: bool) => cameraDialogConfig = "";
+external makeCameraDialogConfig: (~videoMode: bool) => cameraDialogConfig;
 
 [@bs.module "react-native"] [@bs.scope "ImagePickerIOS"]
 external openCameraDialog:
   (cameraDialogConfig, unit => unit, error => unit) => unit =
-  "";
+  "openCameraDialog";
 
 let openCameraDialog = (~videoMode, ~onSuccess, ~onError) =>
   openCameraDialog(makeCameraDialogConfig(~videoMode), onSuccess, onError);
@@ -31,13 +31,12 @@ type selectDialogConfig = {
 
 [@bs.obj]
 external makeSelectDialogConfig:
-  (~showImages: bool, ~showVideos: bool) => selectDialogConfig =
-  "";
+  (~showImages: bool, ~showVideos: bool) => selectDialogConfig;
 
 [@bs.module "react-native"] [@bs.scope "ImagePickerIOS"]
 external openSelectDialog:
   (selectDialogConfig, string => unit, error => unit) => unit =
-  "";
+  "openSelectDialog";
 
 let openSelectDialog = (~showImages, ~showVideos, ~onSuccess, ~onError) =>
   openSelectDialog(

--- a/src/imageStore.re
+++ b/src/imageStore.re
@@ -3,16 +3,16 @@ type error;
 type base64Image = string;
 
 [@bs.module "react-native"] [@bs.scope "ImageStore"]
-external hasImageForTag: (string, bool => unit) => unit = "";
+external hasImageForTag: (string, bool => unit) => unit = "hasImageForTag";
 
 [@bs.module "react-native"] [@bs.scope "ImageStore"]
-external removeImageForTag: string => unit = "";
+external removeImageForTag: string => unit = "removeImageForTag";
 
 [@bs.module "react-native"] [@bs.scope "ImageStore"]
 external addImageFromBase64:
   (base64Image, string => unit, error => unit) => unit =
-  "";
+  "addImageFromBase64";
 
 [@bs.module "react-native"] [@bs.scope "ImageStore"]
 external getBase64ForTag: (string, base64Image => unit, error => unit) => unit =
-  "";
+  "getBase64ForTag";

--- a/src/keyboard.re
+++ b/src/keyboard.re
@@ -35,7 +35,7 @@ let keyboardEventToJs =
 external _addListener: (string, listener('a)) => subscription = "addListener";
 
 [@bs.module "react-native"] [@bs.scope "Keyboard"]
-external dismiss: unit => unit = "";
+external dismiss: unit => unit = "dismiss";
 
 [@bs.module "react-native"] [@bs.scope "Keyboard"]
 external _removeAllListeners: string => unit = "removeAllListeners";
@@ -53,5 +53,5 @@ let removeListener = (keyboardEvent, listener) =>
   _removeListener(keyboardEventToJs(keyboardEvent), listener);
 
 module Subscription = {
-  [@bs.send.pipe: subscription] external remove: unit = "";
+  [@bs.send.pipe: subscription] external remove: unit = "remove";
 };

--- a/src/keyboard.rei
+++ b/src/keyboard.rei
@@ -145,7 +145,7 @@ type keyboardEvent =
   | KeyboardDidChangeFrame;
 
 [@bs.module "react-native"] [@bs.scope "Keyboard"]
-external dismiss: unit => unit = "";
+external dismiss: unit => unit = "dismiss";
 
 let addListener:
   (

--- a/src/linking.re
+++ b/src/linking.re
@@ -18,8 +18,9 @@ let getInitialURL = () =>
      );
 
 [@bs.scope "Linking"] [@bs.module "react-native"]
-external addEventListener: (string, {. "url": string} => unit) => unit = "";
+external addEventListener: (string, {. "url": string} => unit) => unit =
+  "addEventListener";
 
 [@bs.scope "Linking"] [@bs.module "react-native"]
 external removeEventListener: (string, {. "url": string} => unit) => unit =
-  "";
+  "removeEventListener";

--- a/src/linking.rei
+++ b/src/linking.rei
@@ -33,8 +33,9 @@ external openURL: string => Js.Promise.t(unit) = "openURL";
 let getInitialURL: unit => Js.Promise.t(option(string));
 
 [@bs.scope "Linking"] [@bs.module "react-native"]
-external addEventListener: (string, {. "url": string} => unit) => unit = "";
+external addEventListener: (string, {. "url": string} => unit) => unit =
+  "addEventListener";
 
 [@bs.scope "Linking"] [@bs.module "react-native"]
 external removeEventListener: (string, {. "url": string} => unit) => unit =
-  "";
+  "removeEventListener";

--- a/src/nativeEventEmitter.re
+++ b/src/nativeEventEmitter.re
@@ -6,12 +6,16 @@ type emitterSubscription;
 external create: NativeModules.t('a) => t = "NativeEventEmitter";
 
 [@bs.send]
-external addListener: (t, string, 'a => unit) => emitterSubscription = "";
+external addListener: (t, string, 'a => unit) => emitterSubscription =
+  "addListener";
 
-[@bs.send] external removeAllListeners: (t, string) => unit = "";
+[@bs.send]
+external removeAllListeners: (t, string) => unit = "removeAllListeners";
 
-[@bs.send] external removeSubscription: (t, emitterSubscription) => unit = "";
+[@bs.send]
+external removeSubscription: (t, emitterSubscription) => unit =
+  "removeSubscription";
 
 module Subscription = {
-  [@bs.send] external remove: (emitterSubscription, unit) => unit = "";
+  [@bs.send] external remove: (emitterSubscription, unit) => unit = "remove";
 };

--- a/src/netInfo.re
+++ b/src/netInfo.re
@@ -49,23 +49,24 @@ let effectiveConnectionType = effectiveConnectionType =>
 [@bs.module "react-native"] [@bs.scope "NetInfo"]
 external addEventListener:
   ([@bs.as "connectionChange"] _, info => unit) => unit =
-  "";
+  "addEventListener";
 
 [@bs.module "react-native"] [@bs.scope "NetInfo"]
 external removeEventListener:
   ([@bs.as "connectionChange"] _, info => unit) => unit =
-  "";
+  "removeEventListener";
 
 [@bs.module "react-native"] [@bs.scope "NetInfo"]
-external isConnectionExpensive: unit => Js.Promise.t(bool) = "";
+external isConnectionExpensive: unit => Js.Promise.t(bool) =
+  "isConnectionExpensive";
 
 [@bs.module "react-native"] [@bs.scope "NetInfo"]
-external getConnectionInfo: unit => Js.Promise.t(info) = "";
+external getConnectionInfo: unit => Js.Promise.t(info) = "getConnectionInfo";
 
 module IsConnected = {
   type t;
   [@bs.module "react-native"] [@bs.scope "NetInfo"] [@bs.val]
-  external isConnected: t = "";
+  external isConnected: t = "isConnected";
   [@bs.send.pipe: t]
   external _addEventListener:
     ([@bs.as "connectionChange"] _, bool => unit) => unit =

--- a/src/settings.re
+++ b/src/settings.re
@@ -1,13 +1,13 @@
 [@bs.module "react-native"] [@bs.scope "Settings"]
-external get: string => string = "";
+external get: string => string = "get";
 
 [@bs.module "react-native"] [@bs.scope "Settings"]
-external set: Js.Dict.t(string) => unit = "";
+external set: Js.Dict.t(string) => unit = "set";
 
 type watchToken;
 
 [@bs.module "react-native"] [@bs.scope "Settings"]
-external watchKeys: (list(string), unit => unit) => watchToken = "";
+external watchKeys: (list(string), unit => unit) => watchToken = "watchKeys";
 
 [@bs.module "react-native"] [@bs.scope "Settings"]
-external clearWatch: watchToken => unit = "";
+external clearWatch: watchToken => unit = "clearWatch";

--- a/src/vibration.re
+++ b/src/vibration.re
@@ -4,4 +4,4 @@ external _vibrate: (array(int), bool) => unit = "vibrate";
 let vibrate = (~pattern, ~repeat) => _vibrate(pattern, repeat);
 
 [@bs.scope "Vibration"] [@bs.module "react-native"]
-external cancel: unit => unit = "";
+external cancel: unit => unit = "cancel";

--- a/yarn.lock
+++ b/yarn.lock
@@ -991,10 +991,10 @@ braces@^2.3.1:
     split-string "^3.0.2"
     to-regex "^3.0.1"
 
-bs-platform@^5.0.4:
-  version "5.0.4"
-  resolved "https://registry.yarnpkg.com/bs-platform/-/bs-platform-5.0.4.tgz#d406ef43c12d1b19d8546884d8b5b4e0fb709372"
-  integrity sha512-rXM+ztN8wYXQ4ojfFGylvPOf8GRLOvM94QJsMMV9VpsLChKCjesWMNybTZvpoyNsESu2nC5q+C9soG+BPhuUFQ==
+bs-platform@^7.2.2:
+  version "7.2.2"
+  resolved "https://registry.yarnpkg.com/bs-platform/-/bs-platform-7.2.2.tgz#76fdc63e4889458ae3d257a0132107a792f2309c"
+  integrity sha512-PWcFfN+jCTtT/rMaHDhKh+W9RUTpaRunmSF9vbLYcrJbpgCNW6aFKAY33u0P3mLxwuhshN3b4FxqGUBPj6exZQ==
 
 btoa-lite@^1.0.0:
   version "1.0.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -4379,10 +4379,10 @@ readjson@^1.1.0:
   dependencies:
     try-catch "^2.0.0"
 
-reason-react-native@^0.60.1:
-  version "0.60.1"
-  resolved "https://registry.yarnpkg.com/reason-react-native/-/reason-react-native-0.60.1.tgz#eb60dbed6a85ffc4805c08ab4d6a0b551c132c7f"
-  integrity sha512-XJJqG62LW9j7YstzAsD20S8t1kH3uVu19/PT5NByceCACq/8oClBLsFXHXhlPvVvdgKvydGjQo+mNb+JCoJ2Kw==
+reason-react-native@^0.61.1:
+  version "0.61.1"
+  resolved "https://registry.yarnpkg.com/reason-react-native/-/reason-react-native-0.61.1.tgz#fe5cac135a4ed0aacddf9162f532bde7d08781e0"
+  integrity sha512-ep9gThi4dz5CLXzFmNaj/6LgtIKQUbjY4mbYmH3pxnuojC0D7oG7q5GSm3CI8yk32Z+3liY0JrMOx+jVjsuomg==
 
 reason-react@^0.7.0:
   version "0.7.0"


### PR DESCRIPTION
This PR upgrades the library to work with the latest bs-platform release, as well as the latest reason-react-native.

My company is using this package to support some legacy code that we haven't converted over to the newer bindings (yet!), but we wanted to make the jump to bsb v7. The main change here was to add the explicit names of all of the externals, since that changed from a warning to an actual error in v7. I also updated the bindings to use the latest reason-react-native release, which meant a slight change to `<TextInput/>`.

Thanks!